### PR TITLE
rework sl-controls so they don't interfere with clicking on links.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 3.0c2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- rework sl-controls so they don't interfere with clicking on links.
+  [tschanzt]
 
 
 3.0c1 (2013-03-29)

--- a/simplelayout/ui/base/browser/resources/sl-base.js
+++ b/simplelayout/ui/base/browser/resources/sl-base.js
@@ -167,16 +167,15 @@ jQuery(function($){
         var $this = $(this);
         var $bar = $('.sl-toggle-edit-bar', $this);
         var $allbars = $(this).closest('.simplelayout-content').find('.sl-toggle-edit-bar');
-        var $wrapper = $this.closest('.simplelayout-content').find('.sl-actions-wrapper');
-        if ($bar.hasClass('ui-icon-triangle-1-w')){
-            $this.parent().css('width', '600px');
+        var $wrapper = $this.closest('.BlockOverallWrapper').find('.sl-actions-wrapper');
+        if ($wrapper.hasClass('showSimplelayoutControls') != true){
             $wrapper.addClass('showSimplelayoutControls');
-
-            $allbars.removeClass('ui-icon-triangle-1-w').addClass('ui-icon-triangle-1-e');
+            $this.addClass('controlsActive');
+            $this.closest('.sl-controls').css('width', $wrapper.outerWidth() + $this.outerWidth());
         } else {
-            $this.parent().css('width', '10px');
             $wrapper.removeClass('showSimplelayoutControls');
-            $allbars.addClass('ui-icon-triangle-1-w');
+            $this.removeClass('controlsActive');
+            $this.closest('.sl-controls').css('width', '');
         }
     });
 });


### PR DESCRIPTION
@maethu can you take a look at this. I changed the Simplelayout controls so they don't interfere with clicking links.
By default the Controls are now closed and will open on click but only the one clicked not all.
![bildschirmfoto 2014-02-12 um 11 41 49](https://f.cloud.github.com/assets/358342/2148994/27e5e32a-93ee-11e3-82d6-ab888c482899.png)
Open it looks like this:
![bildschirmfoto 2014-02-12 um 11 42 02](https://f.cloud.github.com/assets/358342/2149003/3bfe4a14-93ee-11e3-8330-81485597c984.png)
As you may see the marked block is the one on the bottom, so the actions belong to this one and will vanish if i move the mouse up in the block on top so the links will be accessible without problem.

Link is hidden by actions:
![bildschirmfoto 2014-02-12 um 11 43 48](https://f.cloud.github.com/assets/358342/2149080/56689d0e-93ef-11e3-8582-4e46c4837b03.png)

Link is perfectly visible after moving the mouse.
![bildschirmfoto 2014-02-12 um 11 43 36](https://f.cloud.github.com/assets/358342/2149072/262ad8b4-93ef-11e3-8c6b-99bc8b3de1f5.png)

And since we start with the controls closed and everything is loaded when the user clicks we can set the width so the controls are still on one line.
![bildschirmfoto 2014-02-12 um 14 45 27](https://f.cloud.github.com/assets/358342/2149221/67d97642-93f1-11e3-9171-9d2b7abde835.png)
