### PR TITLE
Ajax requests made by ajaxManager should be POST, not GET.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 3.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Ajax requests made by ajaxManager should be POST, not GET.
+  This solves several caching Issues with latest IE11 and Chrome > 41.
+  [mathias.leimgruber]
 
 
 3.0.3 (2015-03-11)

--- a/simplelayout/ui/base/browser/resources/sl-base.js
+++ b/simplelayout/ui/base/browser/resources/sl-base.js
@@ -93,6 +93,7 @@ simplelayout.refreshParagraph = function(item){
     var fieldname = gup('fieldname',a_el[0].href);
 
     ajaxManager.add({url:'sl_ui_changelayout',
+                            type: 'POST',
                             data:{ uid : uid, layout :layout,viewname:viewname,fieldname:fieldname },
                             success:function(data){
                                 $('#uid_' + uid +' .simplelayout-block-wrapper').replaceWith(data);


### PR DESCRIPTION
This solves several caching Issues with latest IE11 and Chrome > 41.

@jone 